### PR TITLE
return nothing in a void function

### DIFF
--- a/oocairo.c
+++ b/oocairo.c
@@ -612,7 +612,8 @@ from_lua_clusters_table (lua_State *L, cairo_text_cluster_t **clusters,
     }
     *clusters = cairo_text_cluster_allocate(*num);
     if (!*clusters) {
-        return luaL_error(L, "out of memory");
+        luaL_error(L, "out of memory");
+        return;
     }
 
     for (i = 0; i < *num; ++i) {


### PR DESCRIPTION
The luaL_error function is defined to return `int` (even though it never returns and alsoways throws). Anyway returning the functions return value in a void function seems to be not a good idea.